### PR TITLE
Do not log Goodwe's daily production total if less than current

### DIFF
--- a/app/Console/Commands/StoreDailyYield.php
+++ b/app/Console/Commands/StoreDailyYield.php
@@ -32,9 +32,21 @@ class StoreDailyYield extends Command
                 ->dailyProductionLogs()
                 ->firstOrNew(['created_at' => Carbon::today()]);
 
-            $log->total_production = $powerStation->energyProducedToday() * 1000;
+            // The total_production is set to 0 for non-existing
+            // production logs.
+            if (! $log->exists) {
+                $log->total_production = 0;
+            }
 
-            $log->save();
+            $energyProducedToday = $powerStation->energyProducedToday() * 1000;
+
+            // Do not update daily production when retrieved value is
+            // less than currently registered value.
+            if ($energyProducedToday > $log->total_production) {
+                $log->total_production = $energyProducedToday;
+                $log->save();
+            }
+
         });
 
         $this->info('Done');


### PR DESCRIPTION
If the currently obtained value for the daily produced energy in kWh is higher than reported by the Goodwe api, we should not record Goodwe's value but keep the current value in the database.

The total daily production is logged hourly and should not decrease over daytime, only increase.